### PR TITLE
[WIP] Make the API immutable

### DIFF
--- a/src/http-client-configuration.js
+++ b/src/http-client-configuration.js
@@ -67,7 +67,7 @@ export class HttpClientConfiguration {
   */
   withDefaults(defaults: RequestInit): HttpClientConfiguration {
     return new HttpClientConfiguration({
-      defaults: defaults,
+      defaults: { ...defaults, ...this._options.defaults },
       ...this._options
     });
   }

--- a/src/http-client-configuration.js
+++ b/src/http-client-configuration.js
@@ -12,7 +12,9 @@ export class HttpClientConfiguration {
   * The base URL to be prepended to each Request's url before sending.
   * @type {String}
   */
-  baseUrl: string = '';
+  get baseUrl(): string {
+    return this._options.baseUrl;
+  }
 
   /**
   * Default values to apply to init objects when creating Requests. Note that
@@ -21,13 +23,26 @@ export class HttpClientConfiguration {
   * See also https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
   * @type {Object}
   */
-  defaults: RequestInit = {};
+  get defaults(): RequestInit {
+    return this._options.defaults;
+  } 
 
   /**
   * Interceptors to be added to the HttpClient.
   * @type {Array}
   */
-  interceptors: Interceptor[] = [];
+  get interceptors(): Interceptor[] {
+    return this._options.interceptors;
+  }
+  
+  constructor(options: any = {}) {
+    this.options = {
+      baseUrl: '',
+      defaults: {},
+      interceptors: [],
+      ...options
+    };
+  }
 
   /**
   * Sets the baseUrl.
@@ -37,8 +52,10 @@ export class HttpClientConfiguration {
   * @chainable
   */
   withBaseUrl(baseUrl: string): HttpClientConfiguration {
-    this.baseUrl = baseUrl;
-    return this;
+    return new HttpClientConfiguration({
+      baseUrl: baseUrl,
+      ...this._options
+    });
   }
 
   /**
@@ -49,8 +66,10 @@ export class HttpClientConfiguration {
   * @chainable
   */
   withDefaults(defaults: RequestInit): HttpClientConfiguration {
-    this.defaults = defaults;
-    return this;
+    return new HttpClientConfiguration({
+      defaults: defaults,
+      ...this._options
+    });
   }
 
   /**
@@ -64,9 +83,11 @@ export class HttpClientConfiguration {
   * @returns {HttpClientConfiguration}
   * @chainable
   */
-  withInterceptor(interceptor: Interceptor): HttpClientConfiguration {
-    this.interceptors.push(interceptor);
-    return this;
+  addInterceptor(interceptor: Interceptor): HttpClientConfiguration {
+    return new HttpClientConfiguration({
+      interceptors: this._options.interceptors.concat(interceptor),
+      ...this._options
+    });
   }
 
   /**
@@ -77,9 +98,9 @@ export class HttpClientConfiguration {
   * @chainable
   */
   useStandardConfiguration(): HttpClientConfiguration {
-    let standardConfig = { credentials: 'same-origin' };
-    Object.assign(this.defaults, standardConfig, this.defaults);
-    return this.rejectErrorResponses();
+    const standardConfig = { credentials: 'same-origin' };
+    return this.withDefaults(standardConfig)
+      .rejectErrorResponses();
   }
 
   /**


### PR DESCRIPTION
```js
var conf = new Conf();
var withBaseUrl = conf.withBaseUrl(‘foo’);
var withOtherBaseUrl = conf.withBaseUrl(‘other’);

console.log(withBaseUrl.baseUrl); // => "other", WTF?
```

Note, this is a rudimentary suggestion. It's not been tested (I think maybe the order of my `...this._options` is wrong), but I'm on a borrowed PC which doesn't have NPM or node (and my PC is away for service :-/), so I've just changed this in-browser.

The main point is to show how I think the API should look. For most people this will not affect anything at all, but it allows you to do stuff like this:

```js
var serverConfig = new Config().withBaseUrl('blah');
var loginConfig = serverConfig.withDefaults({'some-secret': 'some-value'});
```