### PR TITLE
feat(HttpClient): allow functions as default header values

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -106,6 +106,16 @@ function trackRequestEndWith(promise) {
   return promise;
 }
 
+function parseHeaderValues(headers) {
+  let parsedHeaders = {}
+  for (let name in headers || {}) {
+    if (headers.hasOwnProperty(name)) {
+      parsedHeaders[name] = (typeof headers[name] === 'function') ? headers[name]() : headers[name];
+    }
+  }
+  return parsedHeaders;
+}
+
 function buildRequest(input, init = {}) {
   let defaults = this.defaults || {};
   let source;
@@ -127,9 +137,10 @@ function buildRequest(input, init = {}) {
     body = init.body;
   }
 
-  let requestInit = Object.assign({}, defaults, source, { body });
+  let parsedDefaultHeaders = parseHeaderValues(defaults.headers);
+  let requestInit = Object.assign({}, defaults, {headers: parsedDefaultHeaders}, source, { body });
   let request = new Request((this.baseUrl || '') + url, requestInit);
-  setDefaultHeaders(request.headers, defaults.headers);
+  setDefaultHeaders(request.headers, parsedDefaultHeaders);
 
   return request;
 }


### PR DESCRIPTION
Allow default headers to be set as functions to be evaluated on each request. This allows a very simple way to make sure up to date data is sent with each request. Previously a request interceptor would be needed to gain the same functionality.

Fixes #17