### PR TITLE
fix(http-client): correct type check

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -59,7 +59,7 @@ export class HttpClient {
     } else if (typeof config === 'function') {
       normalizedConfig = new HttpClientConfiguration();
       let c = config(normalizedConfig);
-      if (typeof c === HttpClientConfiguration) {
+      if (c instanceof HttpClientConfiguration) {
         normalizedConfig = c;
       }
     } else {


### PR DESCRIPTION
Result of typeof, which is string always, strictly compared with constructor function.
Such comparison will issue false always, thus causing unreachable if statement.
Most likely you wanted to say instanceof, instead of typeof :)