### PR TITLE
Hotfix/keep baseurl

### DIFF
--- a/dist/amd/aurelia-fetch-client.js
+++ b/dist/amd/aurelia-fetch-client.js
@@ -14,7 +14,7 @@ define(['exports', 'core-js'], function (exports, _coreJs) {
     function HttpClientConfiguration() {
       _classCallCheck(this, HttpClientConfiguration);
 
-      this.baseUrl = '';
+      this.baseUrl = undefined;
       this.defaults = {};
       this.interceptors = [];
     }
@@ -64,7 +64,7 @@ define(['exports', 'core-js'], function (exports, _coreJs) {
       this.activeRequestCount = 0;
       this.isRequesting = false;
       this.isConfigured = false;
-      this.baseUrl = '';
+      this.baseUrl = undefined;
       this.defaults = null;
       this.interceptors = [];
 
@@ -95,7 +95,7 @@ define(['exports', 'core-js'], function (exports, _coreJs) {
         throw new Error('Default headers must be a plain object.');
       }
 
-      this.baseUrl = normalizedConfig.baseUrl;
+      this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
       this.defaults = defaults;
       (_interceptors = this.interceptors).push.apply(_interceptors, normalizedConfig.interceptors || []);
       this.isConfigured = true;

--- a/dist/aurelia-fetch-client.js
+++ b/dist/aurelia-fetch-client.js
@@ -79,7 +79,7 @@ export class HttpClientConfiguration {
   /**
   * The base URL to be prepended to each Request's url before sending.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * Default values to apply to init objects when creating Requests. Note that
@@ -189,7 +189,7 @@ export class HttpClient {
   /**
   * The base URL set by the config.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * The default request init to merge with values specified at request time.
@@ -237,7 +237,7 @@ export class HttpClient {
       throw new Error('Default headers must be a plain object.');
     }
 
-    this.baseUrl = normalizedConfig.baseUrl;
+    this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
     this.defaults = defaults;
     this.interceptors.push(...normalizedConfig.interceptors || []);
     this.isConfigured = true;

--- a/dist/commonjs/aurelia-fetch-client.js
+++ b/dist/commonjs/aurelia-fetch-client.js
@@ -15,7 +15,7 @@ var HttpClientConfiguration = (function () {
   function HttpClientConfiguration() {
     _classCallCheck(this, HttpClientConfiguration);
 
-    this.baseUrl = '';
+    this.baseUrl = undefined;
     this.defaults = {};
     this.interceptors = [];
   }
@@ -65,7 +65,7 @@ var HttpClient = (function () {
     this.activeRequestCount = 0;
     this.isRequesting = false;
     this.isConfigured = false;
-    this.baseUrl = '';
+    this.baseUrl = undefined;
     this.defaults = null;
     this.interceptors = [];
 
@@ -96,7 +96,7 @@ var HttpClient = (function () {
       throw new Error('Default headers must be a plain object.');
     }
 
-    this.baseUrl = normalizedConfig.baseUrl;
+    this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
     this.defaults = defaults;
     (_interceptors = this.interceptors).push.apply(_interceptors, normalizedConfig.interceptors || []);
     this.isConfigured = true;

--- a/dist/es6/aurelia-fetch-client.js
+++ b/dist/es6/aurelia-fetch-client.js
@@ -79,7 +79,7 @@ export class HttpClientConfiguration {
   /**
   * The base URL to be prepended to each Request's url before sending.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * Default values to apply to init objects when creating Requests. Note that
@@ -189,7 +189,7 @@ export class HttpClient {
   /**
   * The base URL set by the config.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * The default request init to merge with values specified at request time.
@@ -237,7 +237,7 @@ export class HttpClient {
       throw new Error('Default headers must be a plain object.');
     }
 
-    this.baseUrl = normalizedConfig.baseUrl;
+    this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
     this.defaults = defaults;
     this.interceptors.push(...normalizedConfig.interceptors || []);
     this.isConfigured = true;

--- a/dist/system/aurelia-fetch-client.js
+++ b/dist/system/aurelia-fetch-client.js
@@ -104,7 +104,7 @@ System.register(['core-js'], function (_export) {
         function HttpClientConfiguration() {
           _classCallCheck(this, HttpClientConfiguration);
 
-          this.baseUrl = '';
+          this.baseUrl = undefined;
           this.defaults = {};
           this.interceptors = [];
         }
@@ -146,7 +146,7 @@ System.register(['core-js'], function (_export) {
           this.activeRequestCount = 0;
           this.isRequesting = false;
           this.isConfigured = false;
-          this.baseUrl = '';
+          this.baseUrl = undefined;
           this.defaults = null;
           this.interceptors = [];
 
@@ -177,7 +177,7 @@ System.register(['core-js'], function (_export) {
             throw new Error('Default headers must be a plain object.');
           }
 
-          this.baseUrl = normalizedConfig.baseUrl;
+          this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
           this.defaults = defaults;
           (_interceptors = this.interceptors).push.apply(_interceptors, normalizedConfig.interceptors || []);
           this.isConfigured = true;

--- a/src/http-client-configuration.js
+++ b/src/http-client-configuration.js
@@ -8,7 +8,7 @@ export class HttpClientConfiguration {
   /**
   * The base URL to be prepended to each Request's url before sending.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * Default values to apply to init objects when creating Requests. Note that

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -25,7 +25,7 @@ export class HttpClient {
   /**
   * The base URL set by the config.
   */
-  baseUrl: string = '';
+  baseUrl: string = undefined;
 
   /**
   * The default request init to merge with values specified at request time.
@@ -73,7 +73,7 @@ export class HttpClient {
       throw new Error('Default headers must be a plain object.');
     }
 
-    this.baseUrl = normalizedConfig.baseUrl;
+    this.baseUrl = normalizedConfig.baseUrl || this.baseUrl;
     this.defaults = defaults;
     this.interceptors.push(...normalizedConfig.interceptors || []);
     this.isConfigured = true;

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -1,5 +1,6 @@
 import {HttpClient} from '../src/http-client';
 
+
 describe('HttpClient', () => {
   let originalFetch = window.fetch;
   let client;
@@ -33,6 +34,30 @@ describe('HttpClient', () => {
         expect(fetch).toHaveBeenCalled();
         done();
       });
+  });
+
+  describe('baseUrl', () => {
+    it("Doesn't overwrite baseUrl on second configure.", () => {
+      let client = new HttpClient();
+
+      client.configure(x => {
+        x.withBaseUrl('foo');
+      });
+
+      expect(client.baseUrl).toBe('foo');
+
+      client.configure(x => {
+        x.withBaseUrl('bar');
+      });
+
+      expect(client.baseUrl).toBe('bar');
+
+      client.configure(x => {
+        x.withDefaults({headers: {foo: 'bar'}});
+      });
+
+      expect(client.baseUrl).toBe('bar');
+    });
   });
 
   describe('interceptors', () => {

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -38,25 +38,25 @@ describe('HttpClient', () => {
 
   describe('baseUrl', () => {
     it("Doesn't overwrite baseUrl on second configure.", () => {
-      let client = new HttpClient();
+      let httpClient = new HttpClient();
 
-      client.configure(x => {
+      httpClient.configure(x => {
         x.withBaseUrl('foo');
       });
 
-      expect(client.baseUrl).toBe('foo');
+      expect(httpClient.baseUrl).toBe('foo');
 
-      client.configure(x => {
+      httpClient.configure(x => {
         x.withBaseUrl('bar');
       });
 
-      expect(client.baseUrl).toBe('bar');
+      expect(httpClient.baseUrl).toBe('bar');
 
-      client.configure(x => {
+      httpClient.configure(x => {
         x.withDefaults({headers: {foo: 'bar'}});
       });
 
-      expect(client.baseUrl).toBe('bar');
+      expect(httpClient.baseUrl).toBe('bar');
     });
   });
 


### PR DESCRIPTION
Upon running configure a second time, the baseUrl got overridden. This is very annoying when combining multiple plugins that use the fetch-client. The same should be done for the defaults, but that's a bit more complex.