### PR TITLE
fix(http-client): handle last null param in fetch method

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -142,7 +142,8 @@ function parseHeaderValues(headers) {
   return parsedHeaders;
 }
 
-function buildRequest(input, init = {}) {
+function buildRequest(input, init) {
+  init || (init = {});
   let defaults = this.defaults || {};
   let source;
   let url;

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -89,6 +89,23 @@ describe('HttpClient', () => {
         });
     });
 
+    it('makes requests with null RequestInit', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+
+      client
+        .fetch('http://example.com/some/cool/path', null)
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+
     it('makes requests with Request inputs', (done) => {
       fetch.and.returnValue(emptyResponse(200));
 


### PR DESCRIPTION
Guys, I've found quite subtle bug, which I'd like to share with you:
```js
function buildRequest(input, init = {}) {
 ...
}
```
What is wrong with this code? Nothing, until you pass null as a last parameter. If the value of init is null, default parameter will not be applied. So to null or not to null? The answer is: ```typeof null``` :)