### PR TITLE
fix(style) : fix style typo

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -41,7 +41,7 @@ export class HttpClient {
   */
   constructor() {
     if (typeof fetch === 'undefined') {
-      throw new Error('HttpClient requires a Fetch API implementation, but the current environment doesn\'t support it. You may need to load a polyfill such as https://github.com/github/fetch.');
+      throw new Error('HttpClient requires a Fetch API implementation, but the current environment doesn\'t support it. You may need to load a polyfill such as https://github.com/github/fetch');
     }
   }
 


### PR DESCRIPTION
When i have this exception on vscode terminal link handler,  the dot uses on the link