### PR TITLE
fix(http-client): Rework application/json header

### DIFF
--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -515,7 +515,7 @@ describe('HttpClient', () => {
 
     it('uses default content-type header', (done) => {
       fetch.and.returnValue(emptyResponse(200));
-      let contentType = 'application/json;charset=UTF-8';
+      let contentType = 'application/octet-stream';
       client.defaults = { method: 'post', body: '{}', headers: { 'content-type': contentType } };
 
       client.fetch('path')


### PR DESCRIPTION
Before, I was adding it as a default to be overridden, but this didn't match the previous behavior closely enough. The old behavior was to return a Blob from `json()` with `content-type: application/json`, which the fetch client would automatically pick up if no header was present. I've removed the default header and instead added a check when there is no content-type header and the body is valid json. To check the json I use `JSON.parse`, which might have performance issues on very big json objects, but unlikely to cause trouble for anyone.

closes #90