### PR TITLE
(feat): convenient helper functions

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -123,6 +123,75 @@ export class HttpClient {
 
     return this::trackRequestEndWith(promise);
   }
+
+  /**
+  * Calls fetch as a GET request.
+  *
+  * @param input The resource that you wish to fetch. Either a
+  * Request object, or a string containing the URL of the resource.
+  * @param init An options object containing settings to be applied to
+  * the Request.
+  * @returns A Promise for the Response from the fetch request.
+  */
+  get(input: Request|string, init?: RequestInit): Promise<Response> {
+    return this.fetch(input, init);
+  }
+
+  /**
+  * Calls fetch with request method set to POST.
+  *
+  * @param input The resource that you wish to fetch. Either a
+  * Request object, or a string containing the URL of the resource.
+  * @param body The body of the request.
+  * @param init An options object containing settings to be applied to
+  * the Request.
+  * @returns A Promise for the Response from the fetch request.
+  */
+  post(input: Request|string, body?: any, init?: RequestInit): Promise<Response> {
+    return this::callFetch(input, body, init, 'post');
+  }
+
+  /**
+  * Calls fetch with request method set to PUT.
+  *
+  * @param input The resource that you wish to fetch. Either a
+  * Request object, or a string containing the URL of the resource.
+  * @param body The body of the request.
+  * @param init An options object containing settings to be applied to
+  * the Request.
+  * @returns A Promise for the Response from the fetch request.
+  */
+  put(input: Request|string, body?: any, init?: RequestInit): Promise<Response> {
+    return this::callFetch(input, body, init, 'put');
+  }
+
+  /**
+  * Calls fetch with request method set to PATCH.
+  *
+  * @param input The resource that you wish to fetch. Either a
+  * Request object, or a string containing the URL of the resource.
+  * @param body The body of the request.
+  * @param init An options object containing settings to be applied to
+  * the Request.
+  * @returns A Promise for the Response from the fetch request.
+  */
+  put(input: Request | string, body ?: any, init ?: RequestInit): Promise < Response > {
+    return this:: callFetch(input, body, init, 'patch');
+  }
+
+  /**
+  * Calls fetch with request method set to DELETE.
+  *
+  * @param input The resource that you wish to fetch. Either a
+  * Request object, or a string containing the URL of the resource.
+  * @param body The body of the request.
+  * @param init An options object containing settings to be applied to
+  * the Request.
+  * @returns A Promise for the Response from the fetch request.
+  */
+  delete(input: Request|string, body?: any, init?: RequestInit): Promise<Response> {
+    return this::callFetch(input, body, init, 'delete');
+  }
 }
 
 const absoluteUrlRegexp = /^([a-z][a-z0-9+\-.]*:)?\/\//i;
@@ -237,4 +306,15 @@ function identity(x) {
 
 function thrower(x) {
   throw x;
+}
+
+function callFetch(input, body, init, method) {
+  if (!init) {
+    init = {};
+  }
+  init.method = method;
+  if (body) {
+    init.body = body;
+  }
+  return this.fetch(input, init);
 }

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -256,7 +256,7 @@ describe('HttpClient', () => {
   describe('patch', () => {
     it('sets method to PATCH and body of request and calls fetch', () => {
       client
-        .put('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
+        .patch('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {
           expect(result.ok).toBe(true);
         })

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -127,7 +127,7 @@ describe('HttpClient', () => {
 
     it('makes proper requests with JSON.stringify inputs', (done) => {
       fetch.and.returnValue(emptyResponse(200));
-      
+
       client
         .fetch('http://example.com/some/cool/path', {
           method: 'post',
@@ -189,6 +189,91 @@ describe('HttpClient', () => {
 
       client
         .fetch(new Request('some/cool/path'))
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('get', () => {
+    it('passes-through to fetch', () => {
+      client
+        .get('http://example.com/some/cool/path')
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('post', () => {
+    it('sets method to POST and body of request and calls fetch', () => {
+      client
+        .post('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('put', () => {
+    it('sets method to PUT and body of request and calls fetch', () => {
+      client
+        .put('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('patch', () => {
+    it('sets method to PATCH and body of request and calls fetch', () => {
+      client
+        .put('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
+        .then(result => {
+          expect(result.ok).toBe(true);
+        })
+        .catch(result => {
+          expect(result).not.toBe(result);
+        })
+        .then(() => {
+          expect(fetch).toHaveBeenCalled();
+          done();
+        });
+    });
+  });
+
+  describe('delete', () => {
+    it('sets method to DELETE and body of request and calls fetch', () => {
+      client
+        .delete('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {
           expect(result.ok).toBe(true);
         })


### PR DESCRIPTION
add get, post, put, patch and delete functions that improve ease of use and readability. before change, making fetch requests other than GET involved explicitly defining options to set HTTP method and body.

I created some unit tests although I don't know how effective they are, and exactly how to write them for a more meaningful assertion.