### PR TITLE
feat(all): add retry functionality

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,9 +7,14 @@ System.config({
   },
 
   map: {
+    "aurelia-pal": "npm:aurelia-pal@1.8.0",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.8.0",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.1.1",
+    "npm:aurelia-pal-browser@1.8.0": {
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
+    },
     "npm:aurelia-polyfills@1.1.1": {
-      "aurelia-pal": "npm:aurelia-pal@1.0.0"
+      "aurelia-pal": "npm:aurelia-pal@1.8.0"
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -26,15 +26,21 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "aurelia-fetch-client",
     "format": "amd",
     "directories": {
       "dist": "dist/amd"
     },
+    "dependencies": {
+      "aurelia-pal": "^1.3.0"
+    },
     "devDependencies": {
+      "aurelia-pal-browser": "^1.0.0",
       "aurelia-polyfills": "^1.0.0-beta.2.0.0"
     }
+  },
+  "dependencies": {
+    "aurelia-pal": "^1.3.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",

--- a/src/http-client-configuration.js
+++ b/src/http-client-configuration.js
@@ -1,4 +1,5 @@
 import {RequestInit, Interceptor} from './interfaces';
+import {RetryInterceptor} from './retry-interceptor';
 
 /**
 * A class for configuring HttpClients.
@@ -86,6 +87,12 @@ export class HttpClientConfiguration {
   */
   rejectErrorResponses(): HttpClientConfiguration {
     return this.withInterceptor({ response: rejectOnError });
+  }
+
+  withRetry( config?: RetryConfiguration) {
+    const interceptor : Interceptor = new RetryInterceptor(config);
+
+    return this.withInterceptor(interceptor);
   }
 }
 

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -1,5 +1,6 @@
 import {HttpClientConfiguration} from './http-client-configuration';
 import {RequestInit, Interceptor} from './interfaces';
+import {RetryInterceptor} from './retry-interceptor';
 
 /**
 * An HTTP client based on the Fetch API.
@@ -77,6 +78,21 @@ export class HttpClient {
       // Headers instances are not iterable in all browsers. Require a plain
       // object here to allow default headers to be merged into request headers.
       throw new Error('Default headers must be a plain object.');
+    }
+
+    let interceptors = normalizedConfig.interceptors;
+
+    if (interceptors && interceptors.length ) {
+      // find if there is a RetryInterceptor
+      if (interceptors.filter( x => RetryInterceptor.prototype.isPrototypeOf(x)).length > 1) {
+        throw new Error('Only one RetryInterceptor is allowed.');
+      }
+
+      const retryInterceptorIndex = interceptors.findIndex( x => RetryInterceptor.prototype.isPrototypeOf(x));
+
+      if (retryInterceptorIndex >= 0 && retryInterceptorIndex !== interceptors.length - 1) {
+        throw new Error('The retry interceptor must be the last interceptor defined.');
+      }
     }
 
     this.baseUrl = normalizedConfig.baseUrl;

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -43,7 +43,7 @@ interface Interceptor {
    * previous interceptor.
    * @returns The response; or a Promise for one.
    */
-  responseError?: (error: any, request?: Request) => Response|Promise<Response>;
+  responseError?: (error: any, request?: Request, httpClient? : HttpClient) => Response|Promise<Response>;
 }
 
 /**
@@ -100,4 +100,14 @@ interface RequestInit {
    * An AbortSignal to set request’s signal.
    */
   signal?: AbortSignal;
+}
+
+interface RetryConfiguration {
+  maxRetries: number;
+  interval?: number;
+  strategy?: number|(retryCount: number) => number;
+  minRandomInterval?: number;
+  maxRandomInterval?: number;
+  doRetry?: (response: Response, request: Request) => boolean | Promise<boolean>;
+  beforeRetry?: (request: Request, client: HttpClient) => Request | Promise<Request>;
 }

--- a/src/retry-interceptor.js
+++ b/src/retry-interceptor.js
@@ -1,0 +1,115 @@
+import { PLATFORM } from 'aurelia-pal';
+import { Interceptor, RetryConfiguration } from './interfaces';
+
+export const retryStrategy = {
+  fixed: 0,
+  incremental: 1,
+  exponential: 2,
+  random: 3
+};
+
+const defaultRetryConfig: RetryConfiguration = {
+  maxRetries: 3,
+  interval: 1000,
+  strategy: retryStrategy.fixed
+};
+
+export class RetryInterceptor implements Interceptor {
+  retryConfig: RetryConfiguration;
+
+  constructor(retryConfig?: RetryConfiguration) {
+    this.retryConfig = Object.assign({}, defaultRetryConfig, retryConfig || {});
+
+    if (this.retryConfig.strategy === retryStrategy.exponential &&
+      this.retryConfig.interval <= 1000) {
+      throw new Error('An interval less than or equal to 1 second is not allowed when using the exponential retry strategy');
+    }
+  }
+
+  request(request) {
+    if (!request.retryConfig) {
+      request.retryConfig = Object.assign({}, this.retryConfig);
+      request.retryConfig.counter = 0;
+    }
+
+    // do this on every request
+    request.retryConfig.requestClone = request.clone();
+
+    return request;
+  }
+
+  response(response, request) {
+    // retry was successful, so clean up after ourselves
+    delete request.retryConfig;
+    return response;
+  }
+
+  responseError(error, request, httpClient) {
+    const { retryConfig } = request;
+    const { requestClone } = retryConfig;
+    return Promise.resolve().then(() => {
+      if (retryConfig.counter < retryConfig.maxRetries) {
+        const result = retryConfig.doRetry ? retryConfig.doRetry(error, request) : true;
+
+        return Promise.resolve(result).then(doRetry => {
+          if (doRetry) {
+            retryConfig.counter++;
+            return new Promise(resolve => PLATFORM.global.setTimeout(resolve, calculateDelay(retryConfig) || 0)).then(() => {
+              let newRequest = requestClone.clone();
+              if (typeof (retryConfig.beforeRetry) === 'function') {
+                return retryConfig.beforeRetry(newRequest, httpClient);
+              }
+              return newRequest;
+            }).then(newRequest => {
+              return httpClient.fetch(Object.assign(newRequest, { retryConfig }));
+            });
+          }
+
+          // no more retries, so clean up
+          delete request.retryConfig;
+          throw error;
+        });
+      }
+      // no more retries, so clean up
+      delete request.retryConfig;
+      throw error;
+    });
+  }
+}
+
+function calculateDelay(retryConfig: RetryConfiguration) {
+  const { interval, strategy, minRandomInterval, maxRandomInterval, counter } = retryConfig;
+
+  if (typeof (strategy) === 'function') {
+    return retryConfig.strategy(counter);
+  }
+
+  switch (strategy) {
+    case (retryStrategy.fixed):
+      return retryStrategies[retryStrategy.fixed](interval);
+    case (retryStrategy.incremental):
+      return retryStrategies[retryStrategy.incremental](counter, interval);
+    case (retryStrategy.exponential):
+      return retryStrategies[retryStrategy.exponential](counter, interval);
+    case (retryStrategy.random):
+      return retryStrategies[retryStrategy.random](counter, interval, minRandomInterval, maxRandomInterval);
+    default:
+      throw new Error('Unrecognized retry strategy');
+  }
+}
+
+const retryStrategies = [
+  // fixed
+  interval => interval,
+
+  // incremental
+  (retryCount, interval) => interval * retryCount,
+
+  // exponential
+  (retryCount, interval) => retryCount === 1 ? interval : Math.pow(interval, retryCount) / 1000,
+
+  // random
+  (retryCount, interval, minRandomInterval = 0, maxRandomInterval = 60000) => {
+    return Math.random() * (maxRandomInterval - minRandomInterval) + minRandomInterval;
+  }
+];

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,4 @@
+import 'aurelia-polyfills';
+import {initialize} from 'aurelia-pal-browser';
+
+initialize();


### PR DESCRIPTION
I'd like some input on this, especially regarding the names of the callbacks on the `RetryConfiguration` interface. 

This PR adds retry functionality to the Aurelia Fetch Client while minimally changing the client code itself. It gives the user the ability to modify either the request or the HttpClient itself (mostly allowing them to call the configure method to, for example, update default headers with a new auth token value. The number of retries and retry delay are set when configuring the HttpClient instance by calling `withRetry` on the configuration object and passing in a `RetryConfiguration` object. 

There aren't any unit tests currently, but I'll be working to add them.