### PR TITLE
feat(interface): add signal entry to RequestInit interface

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -95,4 +95,9 @@ interface RequestInit {
   * Contains the subresource integrity value of the request (e.g., sha256-BpfBw7ivV8q2jLiT13fxDYAe2tJllusRSZ273h2nFSE=).
   */
   integrity?: string;
+
+  /**
+   * An AbortSignal to set request’s signal.
+   */
+  signal?: AbortSignal;
 }

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -200,6 +200,27 @@ describe('HttpClient', () => {
           done();
         });
     });
+
+    it('makes request and aborts with an AbortController signal', (done) => {
+      fetch = window.fetch = originalFetch
+
+      const controller = new AbortController();
+ 
+      client
+        .fetch('http://jsonplaceholder.typicode.com/users', {signal: controller.signal})
+        .then(result => {
+          expect(result).not.toBe(result);
+        })
+        .catch(result => {
+          expect(result instanceof Error).toBe(true);
+          expect(result.name).toBe('AbortError');
+        })
+        .then(() => {
+          done();
+        });
+
+        controller.abort();
+    });
   });
 
   describe('interceptors', () => {


### PR DESCRIPTION
While the fetch client actually works with AbortSignal out of the box, i updated the interface for typescript and added a test to show that it works as it is now.

@see https://fetch.spec.whatwg.org/#request-class

closes #102

Note: With node v7.7.1 no polyfill was needed for the test. Lower versions might need a polyfill eg https://www.npmjs.com/package/abortcontroller-polyfill