### PR TITLE
Fixes wrong method name and unit tests

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -230,8 +230,8 @@ export class HttpClient {
   * the Request.
   * @returns A Promise for the Response from the fetch request.
   */
-  put(input: Request | string, body ?: any, init ?: RequestInit): Promise < Response > {
-    return this:: callFetch(input, body, init, 'patch');
+  patch(input: Request|string, body?: any, init?: RequestInit): Promise<Response> {
+    return this::callFetch(input, body, init, 'patch');
   }
 
   /**

--- a/test/http-client.spec.js
+++ b/test/http-client.spec.js
@@ -226,7 +226,9 @@ describe('HttpClient', () => {
   });
 
   describe('get', () => {
-    it('passes-through to fetch', () => {
+    it('passes-through to fetch', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+
       client
         .get('http://example.com/some/cool/path')
         .then(result => {
@@ -243,7 +245,9 @@ describe('HttpClient', () => {
   });
 
   describe('post', () => {
-    it('sets method to POST and body of request and calls fetch', () => {
+    it('sets method to POST and body of request and calls fetch', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+
       client
         .post('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {
@@ -260,7 +264,9 @@ describe('HttpClient', () => {
   });
 
   describe('put', () => {
-    it('sets method to PUT and body of request and calls fetch', () => {
+    it('sets method to PUT and body of request and calls fetch', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+
       client
         .put('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {
@@ -277,7 +283,9 @@ describe('HttpClient', () => {
   });
 
   describe('patch', () => {
-    it('sets method to PATCH and body of request and calls fetch', () => {
+    it('sets method to PATCH and body of request and calls fetch', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+
       client
         .patch('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {
@@ -294,7 +302,9 @@ describe('HttpClient', () => {
   });
 
   describe('delete', () => {
-    it('sets method to DELETE and body of request and calls fetch', () => {
+    it('sets method to DELETE and body of request and calls fetch', (done) => {
+      fetch.and.returnValue(emptyResponse(200));
+      
       client
         .delete('http://example.com/some/cool/path', JSON.stringify({ test: 'object' }))
         .then(result => {


### PR DESCRIPTION
This fixes a wrong method name and the unit tests for the client's convenience helpers. I had fixed these before but I must have mistakenly removed them somehow. Sorry about that!