### PR TITLE
build: Use TypeScript 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "run-sequence": "^1.2.2",
     "through2": "^2.0.1",
     "typedoc": "^0.11.1",
-    "typescript": "^1.9.0-dev.20160622-1.0",
+    "typescript": "^2.7.0",
     "vinyl": "^1.1.1",
     "vinyl-paths": "^2.1.0",
     "yargs": "^4.8.1"


### PR DESCRIPTION
The typings properly type using the AbortSignal class which was added to TypeScript at 2.7.0. This PR updates the TypeScript dependency in the package.json.