### PR TITLE
(feat): adds an aurelia-fetch-client-request-started event

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -254,6 +254,10 @@ const absoluteUrlRegexp = /^([a-z][a-z0-9+\-.]*:)?\/\//i;
 
 function trackRequestStart() {
   this.isRequesting = !!(++this.activeRequestCount);
+  if (this.isRequesting) {
+    let evt = DOM.createCustomEvent('aurelia-fetch-client-request-started', { bubbles: true, cancelable: true });
+    setTimeout(() => DOM.dispatchEvent(evt), 1);
+  }
 }
 
 function trackRequestEnd() {


### PR DESCRIPTION
adds a new `aurelia-fetch-client-request-started` event that fires when fetch client has started a new request. a `aurelia-fetch-client-requests-drained` event already exists that complements this new event.