### PR TITLE
fetch-client 1.8.0 breaks my build

### DIFF
--- a/src/retry-interceptor.ts
+++ b/src/retry-interceptor.ts
@@ -45,13 +45,13 @@ export class RetryInterceptor implements Interceptor {
     return request;
   }
 
-  response(response: Response, request: Request): Response {
+  response(response: Response, request?: Request): Response {
     // retry was successful, so clean up after ourselves
     delete (request as any).retryConfig;
     return response;
   }
 
-  responseError(error: Response, request: Request, httpClient: HttpClient) {
+  responseError(error: Response, request?: Request, httpClient?: HttpClient) {
     const { retryConfig } = request as Request & { retryConfig: RetryConfiguration };
     const { requestClone } = retryConfig;
     return Promise.resolve().then(() => {


### PR DESCRIPTION
After upgrading `aurelia-fetch-client` in one of my apps from `1.7.0` to `1.8.0` the build started breaking with the following error:

```
../../node_modules/aurelia-fetch-client/dist/aurelia-fetch-client.d.ts(310,2): error TS2416: Property 'response' in type 'RetryInterceptor' is not assignable to the same property in base type 'Interceptor'.
  Type '(response: Response, request: Request) => Response' is not assignable to type '(response: Response, request?: Request | undefined) => Response | Promise<Response>'.
    Types of parameters 'request' and 'request' are incompatible.
      Type 'Request | undefined' is not assignable to type 'Request'.
        Type 'undefined' is not assignable to type 'Request'.
../../node_modules/aurelia-fetch-client/dist/aurelia-fetch-client.d.ts(311,2): error TS2416: Property 'responseError' in type 'RetryInterceptor' is not assignable to the same property in base type 'Interceptor'.
  Type '(error: Response, request: Request, httpClient: HttpClient) => Promise<Response>' is not assignable to type '(error: any, request?: Request | undefined, httpClient?: HttpClient | undefined) => Response | Promise<Response>'.
    Types of parameters 'request' and 'request' are incompatible.
      Type 'Request | undefined' is not assignable to type 'Request'.
        Type 'undefined' is not assignable to type 'Request'.
```

This PR changes `RetryInterceptor` so it conforms to the `Interceptor` interface.